### PR TITLE
Fixing proxy setting

### DIFF
--- a/src/TwoCaptcha.php
+++ b/src/TwoCaptcha.php
@@ -647,7 +647,6 @@ class TwoCaptcha
             $proxy = $params['proxy'];
             $params['proxy'] = $proxy['uri'];
             $params['proxytype'] = $proxy['type'];
-            unset($params['proxy']);
         }
     }
 


### PR DESCRIPTION
Hi folks,

This PR acts in removing a weird "unset" that was unsetting the proxy URL that was already setted.

I was trying to apply some proxy use with this lib for 2catpcha but the "proxy" URL are never sent in ApiClient, just "proxytype".

So looking in your source-code I could found some weird code:

```
$proxy = $params['proxy'];
$params['proxy'] = $proxy['uri'];
$params['proxytype'] = $proxy['type'];
unset($params['proxy']);
```

As you can see in the second line we are setting the proxy url as `$params['proxy'] = $proxy['uri'];` but in the last line `unset($params['proxy']);` the script are removing the proxy url that was setted some lines before.

If you aprove this PR, that will be needed to submit a new version to composer packagist.